### PR TITLE
Improve error reporting and allow to change the DRI render node path at runtime

### DIFF
--- a/src/drm/view-backend-drm.cpp
+++ b/src/drm/view-backend-drm.cpp
@@ -178,9 +178,12 @@ ViewBackend::ViewBackend(struct wpe_view_backend* backend)
         });
 
     // FIXME: This path should be retrieved via udev.
-    drm.fd = open("/dev/dri/card0", O_RDWR | O_CLOEXEC);
+    const char* renderCard = getenv("WPE_RENDER_CARD");
+    if (!renderCard)
+        renderCard = "/dev/dri/card0";
+    drm.fd = open(renderCard, O_RDWR | O_CLOEXEC);
     if (drm.fd < 0) {
-        fprintf(stderr, "ViewBackend: couldn't connect DRM\n");
+        fprintf(stderr, "ViewBackend: couldn't connect DRM to card %s\n", renderCard);
         return;
     }
 

--- a/src/gbm/renderer-backend-egl-gbm.cpp
+++ b/src/gbm/renderer-backend-egl-gbm.cpp
@@ -39,12 +39,18 @@ namespace GBM {
 struct Backend {
     Backend()
     {
-        fd = open("/dev/dri/renderD128", O_RDWR | O_CLOEXEC | O_NOCTTY | O_NONBLOCK);
-        if (fd < 0)
+        const char* renderNode = getenv("WPE_RENDER_NODE");
+        if (!renderNode)
+            renderNode = "/dev/dri/renderD128";
+        fd = open(renderNode, O_RDWR | O_CLOEXEC | O_NOCTTY | O_NONBLOCK);
+        if (fd < 0) {
+            fprintf(stderr, "FATAL: Unable to open the render node device %s\n", renderNode);
             return;
+        }
 
         device = gbm_create_device(fd);
         if (!device) {
+            fprintf(stderr, "FATAL: Unable to create a gbm device on render node %s\n", renderNode);
             close(fd);
             return;
         }

--- a/src/mesa.cpp
+++ b/src/mesa.cpp
@@ -45,10 +45,17 @@
 extern "C" {
 
 static bool under_wayland = !!(std::getenv("WAYLAND_DISPLAY") || std::getenv("WAYLAND_SOCKET"));
+static bool under_x11 = !!(!under_wayland && std::getenv("DISPLAY"));
 
 __attribute__((visibility("default")))
 struct wpe_loader_interface _wpe_loader_interface = {
     [](const char* object_name) -> void* {
+
+        if (under_x11) {
+            fprintf(stderr, "FATAL: WPE Mesa X11 backend not implemented.\n");
+            fprintf(stderr, "Retry from Wayland, from Weston under X11, or from outside X11 (with DRM/KMS)\n");
+            return nullptr;
+        }
 
 #if defined(WPE_MESA_GBM) && WPE_MESA_GBM
         if (!std::strcmp(object_name, "_wpe_view_backend_interface")) {

--- a/src/nc/view-backend-drm.cpp
+++ b/src/nc/view-backend-drm.cpp
@@ -272,9 +272,12 @@ ViewBackend::ViewBackend(struct wpe_view_backend* backend)
         });
 
     // FIXME: This path should be retrieved via udev.
-    drm.fd = open("/dev/dri/card0", O_RDWR | O_CLOEXEC);
+    const char* renderCard = getenv("WPE_RENDER_CARD");
+    if (!renderCard)
+        renderCard = "/dev/dri/card0";
+    drm.fd = open(renderCard, O_RDWR | O_CLOEXEC);
     if (drm.fd < 0) {
-        fprintf(stderr, "ViewBackend: couldn't connect DRM\n");
+        fprintf(stderr, "ViewBackend: couldn't connect DRM to card %s\n", renderCard);
         return;
     }
 


### PR DESCRIPTION

 * Print a loud error when some fatal condition happens rather than
   failing silently. Add a check for under_x11.

 * Allow to change the path to the render node via the environment variable
   WPE_RENDER_NODE. This is useful for systems with more than one GPU where
   the second render node appears as /dev/dri/renderD129