### PR TITLE
Fix a crash when Wayland::ViewBackend is destroyed

### DIFF
--- a/src/wayland/view-backend-wayland.cpp
+++ b/src/wayland/view-backend-wayland.cpp
@@ -75,8 +75,8 @@ private:
     struct wpe_view_backend* m_backend;
 
     struct wl_surface* m_surface;
-    struct xdg_surface* m_xdgSurface;
-    struct ivi_surface* m_iviSurface;
+    struct xdg_surface* m_xdgSurface { nullptr };
+    struct ivi_surface* m_iviSurface { nullptr };
 
     BufferListenerData m_bufferData { nullptr, decltype(m_bufferData.map){ } };
     CallbackListenerData m_callbackData { nullptr, nullptr };


### PR DESCRIPTION
This happens when IVI interface is not available, in which case the
m_iviSurface is not initialized in the constructor. Then the destructor
correctly null-checks it, but since it's uninitilized memory it tries to
destroy it calling ivi_surface_destroy().

Thread 1 (Thread 0x7ffff7fa2d40 (LWP 9622)):
#0  0x00007fffe99ab129 in wl_proxy_marshal () from /usr/lib/x86_64-linux-gnu/libwayland-client.so.0
#1  0x00007fffa43eb24b in ivi_surface_destroy () from /home/cgarcia/gnome/lib/libWPEBackend-default.so
#2  0x00007fffa43ebc01 in Wayland::ViewBackend::~ViewBackend() () from /home/cgarcia/gnome/lib/libWPEBackend-default.so
#3  0x00007fffa43ebc8a in Wayland::ViewBackend::~ViewBackend() () from /home/cgarcia/gnome/lib/libWPEBackend-default.so
#4  0x00007fffa43ec100 in {lambda(void*)#7}::operator() () from /home/cgarcia/gnome/lib/libWPEBackend-default.so
#5  0x00007fffa43ec120 in {lambda(void*)#7}::_FUN () from /home/cgarcia/gnome/lib/libWPEBackend-default.so
#6  0x00007fffec23094a in wpe_view_backend_destroy () from /home/cgarcia/gnome/lib/libWPEBackend.so.0
#7  0x00007ffff4c0126b in WKWPE::View::~View() () from /home/cgarcia/src/git/gnome/WebKit-WPE/WebKitBuild/Release/lib/libWPEWebKit.so.0
#8  0x00007ffff4c012b9 in WKWPE::View::~View() () from /home/cgarcia/src/git/gnome/WebKit-WPE/WebKitBuild/Release/lib/libWPEWebKit.so.0
#9  0x00007ffff4befec4 in webkit_web_view_finalize(_GObject*) () from /home/cgarcia/src/git/gnome/WebKit-WPE/WebKitBuild/Release/lib/libWPEWebKit.so.0
#10 0x00007fffecf644da in g_object_unref (_object=0x5555555c6220) at gobject.c:3314
#11 0x000055555555ccbc in testWebContextEphemeral(Test*, void const*) ()
#12 0x00007ffff7b361c9 in test_case_run (tc=0x5555555afc40) at gtestutils.c:2161
#13 g_test_run_suite_internal (suite=suite@entry=0x5555555ae420, path=path@entry=0x0) at gtestutils.c:2244
#14 0x00007ffff7b36397 in g_test_run_suite_internal (suite=suite@entry=0x5555555ae400, path=path@entry=0x0) at gtestutils.c:2256
#15 0x00007ffff7b36397 in g_test_run_suite_internal (suite=suite@entry=0x5555555ae3a0, path=path@entry=0x0) at gtestutils.c:2256
#16 0x00007ffff7b3658e in g_test_run_suite (suite=0x5555555ae3a0) at gtestutils.c:2332
#17 0x00007ffff7b365b1 in g_test_run () at gtestutils.c:1599
#18 0x000055555555c29a in main ()
