### PR TITLE
Fix a crash in Wayland::Display::~Display() and use release instead of destroy

### DIFF
--- a/src/wayland/display.cpp
+++ b/src/wayland/display.cpp
@@ -587,9 +587,6 @@ Display::~Display()
     if (m_registry)
         wl_registry_destroy(m_registry);
     m_registry = nullptr;
-    if (m_display)
-        wl_display_disconnect(m_display);
-    m_display = nullptr;
 
     if (m_seatData.pointer.object)
         wl_pointer_destroy(m_seatData.pointer.object);
@@ -610,6 +607,10 @@ Display::~Display()
     if (m_seatData.repeatData.eventSource)
         g_source_remove(m_seatData.repeatData.eventSource);
     m_seatData = SeatData{ };
+
+    if (m_display)
+        wl_display_disconnect(m_display);
+    m_display = nullptr;
 }
 
 void Display::registerInputClient(struct wl_surface* surface, struct wpe_view_backend* client)

--- a/src/wayland/display.cpp
+++ b/src/wayland/display.cpp
@@ -483,7 +483,7 @@ static const struct wl_seat_listener g_seatListener = {
             wl_pointer_add_listener(seatData.pointer.object, &g_pointerListener, &seatData);
         }
         if (!hasPointerCap && seatData.pointer.object) {
-            wl_pointer_destroy(seatData.pointer.object);
+            wl_pointer_release(seatData.pointer.object);
             seatData.pointer.object = nullptr;
         }
 
@@ -494,7 +494,7 @@ static const struct wl_seat_listener g_seatListener = {
             wl_keyboard_add_listener(seatData.keyboard.object, &g_keyboardListener, &seatData);
         }
         if (!hasKeyboardCap && seatData.keyboard.object) {
-            wl_keyboard_destroy(seatData.keyboard.object);
+            wl_keyboard_release(seatData.keyboard.object);
             seatData.keyboard.object = nullptr;
         }
 
@@ -505,7 +505,7 @@ static const struct wl_seat_listener g_seatListener = {
             wl_touch_add_listener(seatData.touch.object, &g_touchListener, &seatData);
         }
         if (!hasTouchCap && seatData.touch.object) {
-            wl_touch_destroy(seatData.touch.object);
+            wl_touch_release(seatData.touch.object);
             seatData.touch.object = nullptr;
         }
     },
@@ -589,11 +589,11 @@ Display::~Display()
     m_registry = nullptr;
 
     if (m_seatData.pointer.object)
-        wl_pointer_destroy(m_seatData.pointer.object);
+        wl_pointer_release(m_seatData.pointer.object);
     if (m_seatData.keyboard.object)
-        wl_keyboard_destroy(m_seatData.keyboard.object);
+        wl_keyboard_release(m_seatData.keyboard.object);
     if (m_seatData.touch.object)
-        wl_touch_destroy(m_seatData.touch.object);
+        wl_touch_release(m_seatData.touch.object);
     if (m_seatData.xkb.context)
         xkb_context_unref(m_seatData.xkb.context);
     if (m_seatData.xkb.keymap)


### PR DESCRIPTION
<pre>
Thread 1 (Thread 0x7f920307b340 (LWP 1792)):
#0  0x00007f91f49eb979 in ?? () from /usr/lib/x86_64-linux-gnu/libwayland-client.so.0
No symbol table info available.
#1  0x00007f91f49e7a8e in wl_proxy_destroy () from /usr/lib/x86_64-linux-gnu/libwayland-client.so.0
No symbol table info available.
#2  0x00007f91f6fc8deb in wl_pointer_destroy () from /home/cgarcia/gnome/lib/libWPEBackend-mesa.so.0
No symbol table info available.
#3  0x00007f91f6fcb55b in Wayland::Display::~Display() () from /home/cgarcia/gnome/lib/libWPEBackend-mesa.so.0
No symbol table info available.
#4  0x00007f91f6394940 in __run_exit_handlers (status=0, listp=0x7f91f66f65d8 <__exit_funcs>, run_list_atexit=run_list_atexit@entry=true, run_dtors=run_dtors@entry=true) at exit.c:83
        atfct = <optimized out>
        onfct = <optimized out>
        cxafct = <optimized out>
        f = <optimized out>
#5  0x00007f91f639499a in __GI_exit (status=<optimized out>) at exit.c:105
No locals.
#6  0x00007f91f637f2e8 in __libc_start_main (main=0x55cfe7471970 <main>, argc=1, argv=0x7ffc14544ad8, init=<optimized out>, fini=<optimized out>, rtld_fini=<optimized out>, 
    stack_end=0x7ffc14544ac8) at ../csu/libc-start.c:325
        result = <optimized out>
        unwind_buf = {cancel_jmp_buf = {{jmp_buf = {0, 5045368447410478870, 94351426788144, 140720649554640, 0, 0, 1325001641920667414, 1349000979358392086}, mask_was_saved = 0}}, priv = {
            pad = {0x0, 0x0, 0x7ffc14544ae8, 0x7f92030e3170}, data = {prev = 0x0, cleanup = 0x0, canceltype = 341068520}}}
        not_first_call = <optimized out>
#7  0x000055cfe7471b5a in _start ()
No symbol table info available.
</pre>