### PR TITLE
Ensure glib sources are destroyed and freed

### DIFF
--- a/src/drm/view-backend-drm.cpp
+++ b/src/drm/view-backend-drm.cpp
@@ -287,8 +287,10 @@ ViewBackend::~ViewBackend()
     m_renderer.ipcHost.deinitialize();
 
     m_display.fbMap = { };
-    if (m_display.source)
+    if (m_display.source) {
+        g_source_destroy(m_display.source);
         g_source_unref(m_display.source);
+    }
     m_display.source = nullptr;
     m_display.pageFlipData = { nullptr, { }, { } };
 

--- a/src/nc/renderer-backend-egl.cpp
+++ b/src/nc/renderer-backend-egl.cpp
@@ -151,8 +151,10 @@ Backend::Backend(int hostFd)
 
 Backend::~Backend()
 {
-    if (m_source)
+    if (m_source) {
+        g_source_destroy(m_source);
         g_source_unref(m_source);
+    }
 }
 
 struct wl_surface* Backend::createSurface() const

--- a/src/nc/renderer-host.cpp
+++ b/src/nc/renderer-host.cpp
@@ -82,8 +82,10 @@ RendererHost::RendererHost()
 
 RendererHost::~RendererHost()
 {
-    if (m_source)
+    if (m_source) {
+        g_source_destroy(m_source);
         g_source_unref(m_source);
+    }
 
     if (m_display)
         wl_display_destroy(m_display);

--- a/src/nc/view-backend-drm.cpp
+++ b/src/nc/view-backend-drm.cpp
@@ -534,8 +534,10 @@ ViewBackend::ViewBackend(struct wpe_view_backend* backend)
 
 ViewBackend::~ViewBackend()
 {
-    if (m_display.source)
+    if (m_display.source) {
+        g_source_destroy(m_display.source);
         g_source_unref(m_display.source);
+    }
     m_display.source = nullptr;
 
     if (m_gbm.device)

--- a/src/util/ipc.cpp
+++ b/src/util/ipc.cpp
@@ -64,8 +64,11 @@ void Host::deinitialize()
     if (m_clientFd != -1)
         close(m_clientFd);
 
-    if (m_source)
+    if (m_source) {
         g_source_destroy(m_source);
+        g_source_unref(m_source);
+    }
+
     if (m_socket)
         g_object_unref(m_socket);
 
@@ -148,8 +151,11 @@ void Client::initialize(Handler& handler, int fd)
 
 void Client::deinitialize()
 {
-    if (m_source)
+    if (m_source) {
         g_source_destroy(m_source);
+        g_source_unref(m_source);
+    }
+
     if (m_socket)
         g_object_unref(m_socket);
 

--- a/src/wayland/display.cpp
+++ b/src/wayland/display.cpp
@@ -559,8 +559,10 @@ Display::Display()
 
 Display::~Display()
 {
-    if (m_eventSource)
+    if (m_eventSource) {
+        g_source_destroy(m_eventSource);
         g_source_unref(m_eventSource);
+    }
     m_eventSource = nullptr;
 
     if (m_seatData.cursor.surface)


### PR DESCRIPTION
g_source_destroy() removes the source from the context and releases the
reference added by g_source_attach(). The source can also be destroyed
if the dispatch callback returns G_SOURCE_REMOVE, but it's always safe
to call g_source_destroy() on an already destroyed surce. So, to be
sure, we should always call g_source_destroy() if g_source_attach() was
also called. Finally, g_source_unref() should always be called to
release the initial reference set by g_source_new().