### PR TITLE
Fix build with WPEBackend after 2d53b259 and 2bf3c3ae

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ add_definitions(-DWPE_BACKEND_DRM=1)
 add_definitions(-DWPE_BACKEND_WAYLAND=1)
 add_definitions(${EGL_DEFINITIONS})
 
-pkg_check_modules(WPE wpe REQUIRED)
+pkg_check_modules(WPE wpe-0.1 REQUIRED)
 
 set(WPE_MESA_INCLUDE_DIRECTORIES
     "src/drm"

--- a/include/wpe-mesa/view-backend-exportable-dma-buf.h
+++ b/include/wpe-mesa/view-backend-exportable-dma-buf.h
@@ -31,7 +31,7 @@
 extern "C" {
 #endif
 
-#include <wpe/view-backend.h>
+#include <wpe/wpe.h>
 
 struct wpe_mesa_view_backend_exportable_dma_buf;
 

--- a/src/drm/view-backend-drm.h
+++ b/src/drm/view-backend-drm.h
@@ -27,7 +27,7 @@
 #ifndef wpe_view_backend_drm_h
 #define wpe_view_backend_drm_h
 
-#include <wpe/view-backend.h>
+#include <wpe/wpe.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/gbm/renderer-gbm.h
+++ b/src/gbm/renderer-gbm.h
@@ -29,8 +29,8 @@
 
 #define __GBM__
 
-#include <wpe/renderer-backend-egl.h>
-#include <wpe/renderer-host.h>
+#include <wpe/wpe-egl.h>
+#include <wpe/wpe.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/libxkbcommon/input-libxkbcommon.h
+++ b/src/libxkbcommon/input-libxkbcommon.h
@@ -27,7 +27,7 @@
 #ifndef wpe_mesa_input_libxkbcommon_h
 #define wpe_mesa_input_libxkbcommon_h
 
-#include <wpe/input.h>
+#include <wpe/wpe.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/mesa.cpp
+++ b/src/mesa.cpp
@@ -24,7 +24,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <wpe/loader.h>
+#include <wpe/wpe.h>
 
 #include "input-libxkbcommon.h"
 #include "pasteboard-wayland.h"

--- a/src/nc/nested-compositor.h
+++ b/src/nc/nested-compositor.h
@@ -29,9 +29,8 @@
 
 #define WL_EGL_PLATFORM
 
-#include <wpe/renderer-backend-egl.h>
-#include <wpe/renderer-host.h>
-#include <wpe/view-backend.h>
+#include <wpe/wpe-egl.h>
+#include <wpe/wpe.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/nc/view-backend-wayland.cpp
+++ b/src/nc/view-backend-wayland.cpp
@@ -44,7 +44,7 @@
 #include <wayland-server-core.h>
 #include "wayland-drm-server-protocol.h"
 #include <wayland-server-protocol.h>
-#include <wpe/view-backend.h>
+#include <wpe/wpe.h>
 #include <sys/types.h>
 #include <sys/socket.h>
 

--- a/src/wayland/display.cpp
+++ b/src/wayland/display.cpp
@@ -40,8 +40,7 @@
 #include <unistd.h>
 #include <wayland-client.h>
 #include <wayland-cursor.h>
-#include <wpe/input.h>
-#include <wpe/view-backend.h>
+#include <wpe/wpe.h>
 
 namespace Wayland {
 

--- a/src/wayland/display.h
+++ b/src/wayland/display.h
@@ -30,7 +30,7 @@
 #include <array>
 #include <unordered_map>
 #include <utility>
-#include <wpe/input.h>
+#include <wpe/wpe.h>
 #include <xkbcommon/xkbcommon-compose.h>
 #include <xkbcommon/xkbcommon.h>
 

--- a/src/wayland/pasteboard-wayland.h
+++ b/src/wayland/pasteboard-wayland.h
@@ -27,7 +27,7 @@
 #ifndef wpe_pasteboard_wayland_h
 #define wpe_pasteboard_wayland_h
 
-#include <wpe/pasteboard.h>
+#include <wpe/wpe.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/wayland/view-backend-wayland.cpp
+++ b/src/wayland/view-backend-wayland.cpp
@@ -24,7 +24,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <wpe/view-backend.h>
+#include <wpe/wpe.h>
 
 #include "display.h"
 #include "ipc.h"

--- a/src/wayland/view-backend-wayland.h
+++ b/src/wayland/view-backend-wayland.h
@@ -27,7 +27,7 @@
 #ifndef wpe_view_backend_wayland_h
 #define wpe_view_backend_wayland_h
 
-#include <wpe/view-backend.h>
+#include <wpe/wpe.h>
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
 * Add API version to installed files
   - WPEBackend headers installed versioned at 0.1
 * Enforce single-header includes
   - wpe/wpe.h should be included instead of wpe/input.h, wpe/loader.h,
     wpe/pasteboard.h, wpe/renderer-host.h and wpe/view-backend.h
   - wpe/wpe-egl.h should be included instead of
     wpe/renderer-backend-egl.h